### PR TITLE
pqObjectNaming: list all available object as a last resort

### DIFF
--- a/pqObjectNaming.cxx
+++ b/pqObjectNaming.cxx
@@ -255,6 +255,7 @@ QObject* pqObjectNaming::GetObject(const QString& Name)
     ErrorMessage += QString("Found up to %1\n").arg(
                       pqObjectNaming::GetName(*lastObject));
     }
+  bool foundMatch = false;
   if(lastObject)
     {
     QObjectList matches =
@@ -262,6 +263,15 @@ QObject* pqObjectNaming::GetObject(const QString& Name)
     foreach(QObject* o, matches)
       {
       ErrorMessage  += QString("\tPossible match: %1\n").arg(pqObjectNaming::GetName(*o));
+      foundMatch = true;
+      }
+    }
+  if (!foundMatch)
+    {
+    QObjectList matches = lastObject->findChildren<QObject*>();
+    foreach(QObject* o, matches)
+      {
+      ErrorMessage  += QString("\tAvailable widget: %1\n").arg(pqObjectNaming::GetName(*o));
       }
     }
 


### PR DESCRIPTION
If there are no hints, just list everything that is available. It makes
debugging why things weren't found when widget-private internal
containers are involved vastly easier.