### PR TITLE
Fix warnings on certain version of qt5

### DIFF
--- a/pqCheckEventOverlay.h
+++ b/pqCheckEventOverlay.h
@@ -40,6 +40,9 @@ Display a green or red overlay rectangle on top of parent widget
 */
 class pqCheckEventOverlay : public QWidget
 {
+  Q_OBJECT
+  typedef QWidget Superclass;
+
 public:
   pqCheckEventOverlay(QWidget * parent = 0);
 


### PR DESCRIPTION
this class was missing Q_OBJECT declaration.