### PR TITLE
Using isPrint() instead of isLetterOrNumber() to check if a key is di…

### DIFF
--- a/pqDoubleSpinBoxEventTranslator.cxx
+++ b/pqDoubleSpinBoxEventTranslator.cxx
@@ -80,7 +80,7 @@ bool pqDoubleSpinBoxEventTranslator::translateEvent(QObject* Object, QEvent* Eve
     {
     QKeyEvent* ke = static_cast<QKeyEvent*>(Event);
     QString keyText = ke->text();
-    if(keyText.length() && keyText.at(0).isLetterOrNumber())
+    if(keyText.length() && keyText.at(0).isPrint())
       {
       emit recordEvent(object, "set_double", QString("%1").arg(object->value()));
       }

--- a/pqLineEditEventTranslator.cxx
+++ b/pqLineEditEventTranslator.cxx
@@ -82,7 +82,7 @@ bool pqLineEditEventTranslator::translateEvent(QObject* object, QEvent* event, i
         {
         QKeyEvent* ke = static_cast<QKeyEvent*>(event);
         QString keyText = ke->text();
-        if(keyText.length() && keyText.at(0).isLetterOrNumber())
+        if(keyText.length() && keyText.at(0).isPrint())
           {
           if (leObject)
             {

--- a/pqSpinBoxEventTranslator.cxx
+++ b/pqSpinBoxEventTranslator.cxx
@@ -90,7 +90,7 @@ bool pqSpinBoxEventTranslator::translateEvent(QObject* Object,
     QKeyEvent* ke = static_cast<QKeyEvent*>(Event);
     QString keyText = ke->text();
     this->Value = object->value();
-    if(keyText.length() && keyText.at(0).isLetterOrNumber())
+    if(keyText.length() && keyText.at(0).isPrint())
       {
       emit recordEvent(object, "set_int", QString("%1").arg(object->value()));
       }


### PR DESCRIPTION
…splayed in the widget

This will correct the record event bug in the DelimitedTextReader in paraview.