### PR TITLE
Add new command to pause while processing events.

### DIFF
--- a/pqAbstractMiscellaneousEventPlayer.cxx
+++ b/pqAbstractMiscellaneousEventPlayer.cxx
@@ -39,6 +39,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QFile>
 #include <QThread>
 
+#include "pqEventDispatcher.h"
+
 // Class that encapsulates the protected function QThread::msleep
 class SleeperThread : public QThread
 {
@@ -59,7 +61,6 @@ pqAbstractMiscellaneousEventPlayer::pqAbstractMiscellaneousEventPlayer(QObject* 
 //Allows for execution of testing commands that don't merit their own class
 bool pqAbstractMiscellaneousEventPlayer::playEvent(QObject* Object, const QString& Command, const QString& Arguments, bool& Error)
 {
-
   if (Command == "pause")
     {
     const int value = Arguments.toInt();
@@ -70,7 +71,20 @@ bool pqAbstractMiscellaneousEventPlayer::playEvent(QObject* Object, const QStrin
     Error = true;
     qCritical() << "calling pause on unhandled type " << Object;
     }
-
+  if (Command == "process_events")
+    {
+    bool valid = false;
+    const int ms = Arguments.toInt(&valid);
+    if (valid)
+      {
+      pqEventDispatcher::processEventsAndWait(ms);
+      }
+    else
+      {
+      pqEventDispatcher::processEvents();
+      }
+    return true;
+    }
   return false;
 }
 

--- a/pqAbstractMiscellaneousEventPlayer.h
+++ b/pqAbstractMiscellaneousEventPlayer.h
@@ -34,11 +34,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _pqAbstractMiscellaneousEventPlayer_h
 
 #include "pqWidgetEventPlayer.h"
-/**
-Concrete implementation of pqWidgetEventPlayer that translates high-level ParaView events into low-level Qt events.
 
-\sa pqEventPlayer
-*/
+/// Event playback handler for a collection of miscellaneous commands.
+/// For these events, the "object" on which the event is triggered is generally
+/// immaterial.
+///
+/// Supported commands are:
+/// \li \c pause : pause the application for a fixed time. Time is specified as
+///                the arguments in milliseconds to pause the application for.
+///                This is a sleep i.e. no events will be processed and the
+///                application will appear frozen.
+/// \li \c process_events: process pending events (including timers, etc.).
+///                Optional time (in milliseconds) may be specified to also pause
+///                the test playback. Unlike "pause" however, this will continue
+///                to process all events arising in the application e.g.
+///                responding to timer events.
 class QTTESTING_EXPORT pqAbstractMiscellaneousEventPlayer :
   public pqWidgetEventPlayer
 {


### PR DESCRIPTION
Often in test playback, one may want to pause while still letting the
application process events e.g. timer events. Added a new command (in
pqAbstractMiscellaneousEventPlayer) for the same.