### PR TITLE
Add guard for context menu in some view event players

### DIFF
--- a/pqAbstractItemViewEventPlayer.cxx
+++ b/pqAbstractItemViewEventPlayer.cxx
@@ -41,6 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QList>
 #include <QListWidget>
 #include <QWheelEvent>
+#include <QMenu>
 
 #include "pqEventDispatcher.h"
 
@@ -110,7 +111,10 @@ pqAbstractItemViewEventPlayer::pqAbstractItemViewEventPlayer(QObject* p)
 bool pqAbstractItemViewEventPlayer::playEvent(QObject* Object, const QString& Command, const QString& Arguments, bool& Error)
 {
   QAbstractItemView* object = qobject_cast<QAbstractItemView*>(Object);
-  if (!object)
+  QMenu* contextMenu= qobject_cast<QMenu*>(Object);
+  // if this a QMenu (potentially a context menu of the view),
+  // we should not move onto parent
+  if (!object && !contextMenu)
     {
     // mouse events go to the viewport widget
     object = qobject_cast<QAbstractItemView*>(Object->parent());

--- a/pqAbstractItemViewEventPlayerBase.cxx
+++ b/pqAbstractItemViewEventPlayerBase.cxx
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //#include <QKeyEvent>
 #include <QAbstractItemView>
 #include <QDebug>
+#include <QMenu>
 //-----------------------------------------------------------------------------
 pqAbstractItemViewEventPlayerBase::pqAbstractItemViewEventPlayerBase(QObject* parentObject)
   : Superclass(parentObject)
@@ -94,7 +95,10 @@ bool pqAbstractItemViewEventPlayerBase::playEvent(
   const QString& arguments, int eventType, bool& error)
 {
   QAbstractItemView* abstractItemView= qobject_cast<QAbstractItemView*>(object);
-  if(!abstractItemView)
+  QMenu* contextMenu= qobject_cast<QMenu*>(object);
+  // if this a QMenu (potentially a context menu of the view),
+  // we should not move onto parent
+  if(!abstractItemView && !contextMenu)
     {
     // mouse events go to the viewport widget
     abstractItemView = qobject_cast<QAbstractItemView*>(object->parent());

--- a/pqTreeViewEventPlayer.cxx
+++ b/pqTreeViewEventPlayer.cxx
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ========================================================================*/
 #include "pqTreeViewEventPlayer.h"
 #include <QTreeWidget>
+#include <QMenu>
 #include <QDebug>
 
 //-----------------------------------------------------------------------------
@@ -50,7 +51,10 @@ bool pqTreeViewEventPlayer::playEvent(
   const QString& arguments, int eventType, bool& error)
 {
   QTreeView* treeView= qobject_cast<QTreeView*>(object);
-  if(!treeView)
+  QMenu* contextMenu= qobject_cast<QMenu*>(object);
+  // if this a QMenu (potentially a context menu of the view),
+  // we should not move onto parent
+  if(!treeView && !contextMenu)
     {
     // mouse events go to the viewport widget
     treeView = qobject_cast<QTreeView*>(object->parent());


### PR DESCRIPTION
The pqAbstractItemViewEventPlayer, pqTreeViewEventPlayer and pqAbstractItemViewEventPlayerBase all try to handle an object command for the object's parent if the object itself is not what the players expects. This will not work in case of a context menu for these views, because the context menu's parent is the view, and in some cases, the view and the context menu commands are same, for example, "activate", so the view player will try to handle the command for context menu, which apparently will fail. The fix is not to look at the parent if it is a QMenu.